### PR TITLE
getuto: Re-import the system key as well on updates

### DIFF
--- a/getuto
+++ b/getuto
@@ -101,8 +101,10 @@ EOF
 
 fi
 
-# Refresh all keys from the keyserver.
-
+# Always re-import the system keys because it might be our only source of updates
+# for e.g. revocations, renewals, etc if we're on a firewalled machine.
+gpg --no-permission-warning --batch --import "${ROOT%/}"/usr/share/openpgp-keys/gentoo-release.asc
+# Refresh all keys from the keyserver if we can.
 gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --refresh-keys || true # TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
 
 # Make sure the trustdb is world-readable (again).

--- a/getuto
+++ b/getuto
@@ -99,17 +99,20 @@ if [[ ! -d ${GNUPGHOME} ]] ; then
 	# Make sure the trustdb is world-readable.
 	chmod ugo+r "${GNUPGHOME}/trustdb.gpg"
 
+else
+	# The keydir already exists, so our job is to just to refresh and check
+	# permissions.
+
+	# Always re-import the system keys because it might be our only source of updates
+	# for e.g. revocations, renewals, etc if we're on a firewalled machine.
+	gpg --no-permission-warning --batch --import "${ROOT%/}"/usr/share/openpgp-keys/gentoo-release.asc
+
+	# Refresh all keys from the keyserver if we can.
+	for keyserver in "${mykeyservers[@]}" ; do
+		# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
+		gpg --no-permission-warning --batch --keyserver "${keyserver}" --refresh-keys || true
+	done
 fi
-
-# Always re-import the system keys because it might be our only source of updates
-# for e.g. revocations, renewals, etc if we're on a firewalled machine.
-gpg --no-permission-warning --batch --import "${ROOT%/}"/usr/share/openpgp-keys/gentoo-release.asc
-
-# Refresh all keys from the keyserver if we can.
-for keyserver in "${mykeyservers[@]}" ; do
-	# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
-	gpg --no-permission-warning --batch --keyserver "${keyserver}" --refresh-keys || true
-done
 
 # Make sure the trustdb is world-readable (again).
 chmod ugo+r "${GNUPGHOME}/trustdb.gpg"

--- a/getuto
+++ b/getuto
@@ -20,7 +20,10 @@ set -e
 
 [[ $(whoami) == 'root' ]] || { echo "${0} must be run as root!" ; exit 100 ; }
 
-mykeyserver="hkps://keys.openpgp.org"
+mykeyservers=(
+	"hkps://keys.openpgp.org"
+	"hkps://keys.gentoo.org"
+)
 
 export GNUPGHOME="${ROOT%/}"/etc/portage/gnupg
 
@@ -72,11 +75,12 @@ if [[ ! -d ${GNUPGHOME} ]] ; then
 
 	# List all release engineering keys.
 	# See https://serverfault.com/a/946428.
-
 	myrelkeys=$(gpg --no-permission-warning --batch --list-keys --keyid-format=long --with-colons | grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | grep -v "${mykeyid}")
 
 	# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
-	gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --recv-keys ${myrelkeys} || true
+	for keyserver in "${mykeyservers[@]}" ; do
+		gpg --no-permission-warning --batch --keyserver "${keyserver}" --recv-keys ${myrelkeys} || true
+	done
 
 	# Locally sign all release engineering keys.
 	for relkeyid in ${myrelkeys} ; do
@@ -100,8 +104,12 @@ fi
 # Always re-import the system keys because it might be our only source of updates
 # for e.g. revocations, renewals, etc if we're on a firewalled machine.
 gpg --no-permission-warning --batch --import "${ROOT%/}"/usr/share/openpgp-keys/gentoo-release.asc
+
 # Refresh all keys from the keyserver if we can.
-gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --refresh-keys || true # TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
+for keyserver in "${mykeyservers[@]}" ; do
+	# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
+	gpg --no-permission-warning --batch --keyserver "${keyserver}" --refresh-keys || true
+done
 
 # Make sure the trustdb is world-readable (again).
 chmod ugo+r "${GNUPGHOME}/trustdb.gpg"

--- a/getuto
+++ b/getuto
@@ -14,6 +14,7 @@
 
 # Runtime requirements:
 # app-crypt/gnupg
+# dev-libs/openssl
 # sec-keys/openpgp-keys-gentoo-release
 set -e
 

--- a/getuto
+++ b/getuto
@@ -27,32 +27,30 @@ export GNUPGHOME="${ROOT%/}"/etc/portage/gnupg
 gpgconf --kill gpg-agent
 
 if [[ ! -d ${GNUPGHOME} ]] ; then
-
 	# The directory does not exist yet.
 	mkdir -p "${GNUPGHOME}"
 	chmod u=rwx,go=rx "${GNUPGHOME}"
 
 	# Generate a local ultimate trust anchor key.
-
 	PASS="$(openssl rand -base64 32)"
 
 	KEY_CONFIG_FILE="$(mktemp)"
 	chmod 600 "${KEY_CONFIG_FILE}"
 
-	cat > "${KEY_CONFIG_FILE}" <<EOF
-%echo Generating Portage local OpenPGP trust key
-Key-Type: RSA
-Key-Length: 3072
-Subkey-Type: RSA
-Subkey-Length: 3072
-Name-Real: Portage Local Trust Key
-Name-Comment: local signing only
-Name-Email: portage@localhost
-Expire-Date: 0
-Passphrase: ${PASS}
-%commit
-%echo done
-EOF
+	cat > "${KEY_CONFIG_FILE}" <<-EOF
+	%echo Generating Portage local OpenPGP trust key
+	Key-Type: RSA
+	Key-Length: 3072
+	Subkey-Type: RSA
+	Subkey-Length: 3072
+	Name-Real: Portage Local Trust Key
+	Name-Comment: local signing only
+	Name-Email: portage@localhost
+	Expire-Date: 0
+	Passphrase: ${PASS}
+	%commit
+	%echo done
+	EOF
 
 	gpg --no-permission-warning --batch --generate-key "${KEY_CONFIG_FILE}"
 	rm -f "${KEY_CONFIG_FILE}"
@@ -65,7 +63,6 @@ EOF
 	mykeyid=$(<"${GNUPGHOME}/mykeyid")
 
 	# Import all release engineering keys.
-
 	if [[ ! -f "${ROOT%/}"/usr/share/openpgp-keys/gentoo-release.asc ]] ; then
 		echo "\"${ROOT%/}\"/usr/share/openpgp-keys/gentoo-release.asc not found. Is sec-keys/openpgp-keys-gentoo-release installed?"
 		exit 1
@@ -79,10 +76,9 @@ EOF
 	myrelkeys=$(gpg --no-permission-warning --batch --list-keys --keyid-format=long --with-colons | grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | grep -v "${mykeyid}")
 
 	# Locally sign all release engineering keys.
-
 	for relkeyid in ${myrelkeys} ; do
-
 		gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --recv-keys "${relkeyid}" || true # TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
+
 		# We have to use --quick-lsign-key for this to work with batch: https://dev.gnupg.org/T1606
 		if ! gpg --no-permission-warning --batch --yes --no-tty --passphrase-file="${GNUPGHOME}/pass" --pinentry-mode loopback --quick-lsign-key "${relkeyid}" ; then
 			# But that won't work for subkeys, so fall back to a hackier method.
@@ -93,11 +89,9 @@ EOF
 	done
 
 	# Update the trustdb
-
 	gpg --no-permission-warning --batch --check-trustdb
 
 	# Make sure the trustdb is world-readable.
-
 	chmod ugo+r "${GNUPGHOME}/trustdb.gpg"
 
 fi
@@ -109,5 +103,4 @@ gpg --no-permission-warning --batch --import "${ROOT%/}"/usr/share/openpgp-keys/
 gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --refresh-keys || true # TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
 
 # Make sure the trustdb is world-readable (again).
-
 chmod ugo+r "${GNUPGHOME}/trustdb.gpg"

--- a/getuto
+++ b/getuto
@@ -75,10 +75,11 @@ if [[ ! -d ${GNUPGHOME} ]] ; then
 
 	myrelkeys=$(gpg --no-permission-warning --batch --list-keys --keyid-format=long --with-colons | grep "^fpr" | sed -n 's/^fpr:::::::::\([[:alnum:]]\+\):/\1/p' | grep -v "${mykeyid}")
 
+	# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
+	gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --recv-keys ${myrelkeys} || true
+
 	# Locally sign all release engineering keys.
 	for relkeyid in ${myrelkeys} ; do
-		gpg --no-permission-warning --batch --keyserver "${mykeyserver}" --recv-keys "${relkeyid}" || true # TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
-
 		# We have to use --quick-lsign-key for this to work with batch: https://dev.gnupg.org/T1606
 		if ! gpg --no-permission-warning --batch --yes --no-tty --passphrase-file="${GNUPGHOME}/pass" --pinentry-mode loopback --quick-lsign-key "${relkeyid}" ; then
 			# But that won't work for subkeys, so fall back to a hackier method.

--- a/test-getuto.sh
+++ b/test-getuto.sh
@@ -25,3 +25,6 @@ tar xvf libc-1-r1-1.gpkg.tar -C "${ROOT}"/tmp/binpkg
 for file in image.tar.bz2 metadata.tar.bz2 ; do
 	gpg --verify "${ROOT}"/tmp/binpkg/libc-1-r1-1/${file}.sig
 done
+
+# Try to refresh an existing keyring.
+bash -x getuto


### PR DESCRIPTION
Always re-import the system keys because it might be our only source of updates for e.g. revocations, renewals, etc if we're on a firewalled machine.