### PR TITLE
Enable bash -x if GETUTO_DEBUG is set

### DIFF
--- a/getuto
+++ b/getuto
@@ -18,6 +18,8 @@
 # sec-keys/openpgp-keys-gentoo-release
 # sys-apps/gentoo-functions
 
+[[ ${GETUTO_DEBUG} ]] && set -x
+
 QUIET='1'
 
 [[ $(whoami) == 'root' ]] || { echo "${0} must be run as root!" ; exit 100 ; }


### PR DESCRIPTION
Support enabling verbose bash output if GETUTO_DEBUG is set. Due getuto often being called via portage it is not trivial to get debug output. Especially since setting

```bash
PORTAGE_TRUST_HELPER="bash -x /usr/bin/getuto"
```

fails with

```
!!! Portage trust helper bash -x /usr/bin/getuto for binary packages not found
!!! Continuing, but did you install app-portage/getuto?
```

Side node: As far as I can tell, I see getuto failing with a non-zero exit status if I bootstrap a Gentoo image, where a crossdev emerge is invoked, if
1. My Yubikey containing my secret OpenPGP keys is plugged in
2. The keys are not unlocked

I am not sure how my user's gpg shadows into the gpg of getuto. Especially since getuto sets its own home. That is the motivation for this change, pinpointing the exact command that fails in getuto.