### PR TITLE
Improve gpg cleanup by running separate kill commands.

### DIFF
--- a/getuto
+++ b/getuto
@@ -46,7 +46,8 @@ else
 	}
 fi
 
-gpgconf --kill gpg-agent dirmngr
+gpgconf --kill gpg-agent
+gpgconf --kill dirmngr
 set -e
 
 mykeyservers=(
@@ -206,4 +207,5 @@ fi
 chmod ugo+r "${GNUPGHOME}/trustdb.gpg"
 
 # Clean up.
-gpgconf --kill gpg-agent dirmngr
+gpgconf --kill gpg-agent
+gpgconf --kill dirmngr


### PR DESCRIPTION
gpgconfg --kill doesn't seem to work with multiple args for --kill

Should resolve this https://github.com/projg2/getuto/issues/10