### PR TITLE
getuto: Update LASTRUNFILE on init

### DIFF
--- a/getuto
+++ b/getuto
@@ -185,6 +185,7 @@ if [[ ! -d ${GNUPGHOME} ]] ; then
 	# Make sure the trustdb is world-readable.
 	chmod ugo+r "${GNUPGHOME}/trustdb.gpg"
 
+	touch ${LASTRUNFILE}
 	eend
 else
 	# The keydir already exists, so our job is to just to refresh and check


### PR DESCRIPTION
Should result in fewer unnecessary key refreshes. Maybe a --force option to ignore the lastrun file would make sense.