### PR TITLE
getuto: Improve gpg cleanup by killing all components

### DIFF
--- a/getuto
+++ b/getuto
@@ -46,8 +46,7 @@ else
 	}
 fi
 
-gpgconf --kill gpg-agent
-gpgconf --kill dirmngr
+gpgconf --kill all
 set -e
 
 mykeyservers=(
@@ -207,5 +206,4 @@ fi
 chmod ugo+r "${GNUPGHOME}/trustdb.gpg"
 
 # Clean up.
-gpgconf --kill gpg-agent
-gpgconf --kill dirmngr
+gpgconf --kill all


### PR DESCRIPTION
Kills all components instead of just the gpg-agent and dirmngr. This is more straightforward and should prevent any future issues caused by services not being killed before getuto runs. Prevents services from lingering after getuto completes.