### PR TITLE
getuto: add manual timeout around GPG connection to keyserver.

### DIFF
--- a/getuto
+++ b/getuto
@@ -27,6 +27,9 @@ LASTRUNFILE=${GNUPGHOME}/.getuto.last
 QUIET='1'
 QUIET_GPG=''
 
+GPG_TIMEOUT_TERM='3.5m'
+GPG_TIMEOUT_KILL='5m'
+
 [[ $1 == '-v' ]] && QUIET=''
 #  If QUIET is enabled, pass '--quiet' and suppress GPG homedir permission warnings
 #  These permission warnings cannot be suppressed using gpg.conf
@@ -73,7 +76,7 @@ getuto_refresh() {
 		# Refresh all keys from the keyserver if we can.
 		for keyserver in "${mykeyservers[@]}" ; do
 			# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
-			gpg ${QUIET_GPG} --batch --keyserver "${keyserver}" --refresh-keys || true
+			timeout -k ${GPG_TIMEOUT_KILL} ${GPG_TIMEOUT_TERM} gpg ${QUIET_GPG} --batch --keyserver "${keyserver}" --refresh-keys || true
 		done
 		# We only sign (-> ultimate trust) the keys we originally import, so this is fine and
 		# just serves as an additional refresh method.
@@ -167,7 +170,7 @@ if [[ ! -d ${GNUPGHOME} ]] ; then
 
 	# TODO: keys.openpgp.org lacks a UID for our keys, need to verify email
 	for keyserver in "${mykeyservers[@]}" ; do
-		gpg ${QUIET_GPG} --batch --keyserver "${keyserver}" --recv-keys ${myrelkeys} || true
+		timeout -k ${GPG_TIMEOUT_KILL} ${GPG_TIMEOUT_TERM} gpg ${QUIET_GPG} --batch --keyserver "${keyserver}" --recv-keys ${myrelkeys} || true
 	done
 	# We only sign (-> ultimate trust) the keys we originally import, so this is fine and
 	# just serves as an additional refresh method.


### PR DESCRIPTION
Some kinds of ISP site blocks terminate connection after it is established. This leaves GPG thinking it's connected successfully and waiting for keys.
Add manual timeout invocations over keyserver calls. Set timeout for them longer than GPG connection timeout.

Closes: #22
Closes: #28